### PR TITLE
Remove incorrect undead tag and fix Vvrael destroyer capitalization

### DIFF
--- a/creatures.json
+++ b/creatures.json
@@ -12436,7 +12436,7 @@
     ]
   },
   {
-    "name": "vvrael destroyer",
+    "name": "Vvrael destroyer",
     "level": 108,
     "description": "A strong jawline and shrewd, narrowed eyes are prominent in the features of the Vvrael destroyer's countenance, creating of his mouth a severe line and of his gaze an openly vicious stare. All the malice caught in the creature's eyes make promises to be answered by the muscular, though ephemeral physique obvious even below his segmented pieces of armor. Despite the bulk of his form, the destroyer moves with the militant grace of a seasoned warrior, precise and purposeful.",
     "habitats": [

--- a/creatures.json
+++ b/creatures.json
@@ -7739,7 +7739,6 @@
     ],
     "article": "https://gswiki.play.net/mediawiki/index.php/krynch",
     "tags": [
-      "undead",
       "biped"
     ]
   },

--- a/creatures.json
+++ b/creatures.json
@@ -8886,7 +8886,6 @@
     ],
     "article": "https://gswiki.play.net/mediawiki/index.php/forest_bendith",
     "tags": [
-      "undead",
       "biped"
     ]
   },


### PR DESCRIPTION
* Vvrael should be capitalized for destroyers too
* Forest Bendiths and Krynch are not undead