### PR TITLE
Restore missing /an? / in gem descriptions

### DIFF
--- a/gems.json
+++ b/gems.json
@@ -171,7 +171,7 @@
     "sig": "25e1f045e4565840b00ddbe956c416b8"
   },
   {
-    "description": "selanthbloodjewel",
+    "description": "selanthan bloodjewel",
     "length": 278,
     "noun": "bloodjewel",
     "rarity": "extremely rare",
@@ -918,7 +918,7 @@
     "sig": "739a0c8c0e672153d899db1737e12626"
   },
   {
-    "description": "ceruleglimaerstone",
+    "description": "cerulean glimaerstone",
     "length": 241,
     "noun": "glimaerstone",
     "rarity": "",
@@ -1512,7 +1512,7 @@
     "sig": "10199e7e7b1eb03d5839e2bc2180388a"
   },
   {
-    "description": "piece of carneliquartz",
+    "description": "piece of carnelian quartz",
     "length": 273,
     "noun": "quartz",
     "rarity": "",
@@ -1980,7 +1980,7 @@
     "sig": "aebcafb8f8ff1f590060cf6a0f9460bd"
   },
   {
-    "description": "hazy red seglass disk",
+    "description": "hazy red seaglass disk",
     "length": 0,
     "noun": "disk",
     "rarity": "",
@@ -1989,7 +1989,7 @@
     "sig": "d41d8cd98f00b204e9800998ecf8427e"
   },
   {
-    "description": "mist blue seglass disk",
+    "description": "mist blue seaglass disk",
     "length": 0,
     "noun": "disk",
     "rarity": "",
@@ -1998,7 +1998,7 @@
     "sig": "d41d8cd98f00b204e9800998ecf8427e"
   },
   {
-    "description": "round amber seglass disk",
+    "description": "round amber seaglass disk",
     "length": 0,
     "noun": "disk",
     "rarity": "",
@@ -2007,7 +2007,7 @@
     "sig": "d41d8cd98f00b204e9800998ecf8427e"
   },
   {
-    "description": "smooth green seglass disk",
+    "description": "smooth green seaglass disk",
     "length": 0,
     "noun": "disk",
     "rarity": "",
@@ -2052,7 +2052,7 @@
     "sig": "7a50cddddb1efeda992ce77072358f4d"
   },
   {
-    "description": "blue-banded coquinshell",
+    "description": "blue-banded coquina shell",
     "length": 442,
     "noun": "shell",
     "rarity": "",
@@ -2142,7 +2142,7 @@
     "sig": "eca3568b799556317712e873d039dade"
   },
   {
-    "description": "lavender nassshell",
+    "description": "lavender nassa shell",
     "length": 386,
     "noun": "shell",
     "rarity": "",
@@ -2169,7 +2169,7 @@
     "sig": "40eef90806fa8da271bc9a5553ffc712"
   },
   {
-    "description": "pink-banded coquinshell",
+    "description": "pink-banded coquina shell",
     "length": 441,
     "noun": "shell",
     "rarity": "",
@@ -2214,7 +2214,7 @@
     "sig": "42a40be09ec51fc3f84d8c74ab702a2e"
   },
   {
-    "description": "ruby-lined nassshell",
+    "description": "ruby-lined nassa shell",
     "length": 308,
     "noun": "shell",
     "rarity": "",
@@ -2295,7 +2295,7 @@
     "sig": "ab0e31daeebe8aad8835eaa82f7ef918"
   },
   {
-    "description": "fiery viridisoulstone",
+    "description": "fiery viridian soulstone",
     "length": 184,
     "noun": "soulstone",
     "rarity": "",
@@ -2682,7 +2682,7 @@
     "sig": "c91df128b8238e217a303af31b6dae90"
   },
   {
-    "description": "green errisitopaz",
+    "description": "green errisian topaz",
     "length": 323,
     "noun": "topaz",
     "rarity": "",


### PR DESCRIPTION
Looks like a search and replace on the gem descriptions for something like `s/an? //` mangled some of the names.

**FYI**: I restored seglass to seaglass, but those entries looks like they have [the old descriptions that were updated last year](https://forums.elanthia.online/topic/618/official-gem-description-update) to play more nicely with gem cuttters 